### PR TITLE
Fix OfferingBowl error

### DIFF
--- a/LocationManager/LocationManager.cs
+++ b/LocationManager/LocationManager.cs
@@ -203,7 +203,9 @@ public class Location
 			});
 		}
 
-		Object.Destroy(__instance.m_locationProxyPrefab.GetComponent<LocationProxy>());
+		// LocationProxy has OnDestroy which delays the component removal.
+		// This temporarily duplicates the component so the right one must be searched.
+		Object.Destroy(__instance.m_locationProxyPrefab.GetComponents<LocationProxy>().FirstOrDefault(proxy => proxy.enabled));
 		__instance.m_locationProxyPrefab.AddComponent<LocationProxy>();
 	}
 


### PR DESCRIPTION
There is an issue that multiple Location Managers will duplicate the LocationProxy component.

This happens because LocationProxy has OnDestroy which means the component doesn't get destroyed immediatelly.

In current code, the destroy will always target the original component, while each manager adds a new one.

In fixed code, the correct component is searched (since it will be only enabled one).


Multiple ways to handle this so feel free to refactor as needed.

As usual, I didn't test this because I don't have mod that would use Location Manager. 😅