### PR TITLE
Fix Jotunn incompatibility caused by null entries in AssetBundleLoader.Instance.m_assetLoaders

### DIFF
--- a/LocationManager/LocationManager.cs
+++ b/LocationManager/LocationManager.cs
@@ -391,7 +391,7 @@ public static class PrefabManager
 			int count = bundleLoader.m_assetIDToLoaderIndex.Count;
 			if (count >= bundleLoader.m_assetLoaders.Length)
 			{
-				Array.Resize(ref bundleLoader.m_assetLoaders, bundleLoader.m_assetIDToLoaderIndex.Count + 256);
+				Array.Resize(ref bundleLoader.m_assetLoaders, count + 1);
 			}
 
 			bundleLoader.m_assetLoaders[count] = loader;


### PR DESCRIPTION
When inserting a new assetLoader, LocationManager resizes the `m_assetLoader` array by 256. This creates null entries in the array. 

Jotunn's [AssetManager.CreateNameToAssetID(](https://github.com/Valheim-Modding/Jotunn/blob/82f31de093916fb3f77feff9f296aa75d4dcfc0d/JotunnLib/Managers/AssetManager.cs#L257)) method calls the vanilla SoftReferenceableAssets.Runtime.GetAllAssetPathsInBundleMappedToAssetID() method after LocationManager resizes the array (inserting null entries). Therefore, when Jotunn calls the method the array contains null entries and throws an error. 

This PR changes LocationManager to only resize by 1.

The changes in this PR have been tested along side a Jotunn mod and confirmed to solve the issue. 